### PR TITLE
Select message threads by userID and not by index

### DIFF
--- a/public/src/js/partials/userList.jsx
+++ b/public/src/js/partials/userList.jsx
@@ -97,7 +97,7 @@ var UserList = React.createClass({
 				'user-list__item': true,
 				'clear': true,
 				'user-list__item--new': isNewMessage,
-				'user-list__item--active': this.state.openChatID === index
+				'user-list__item--active': this.state.openChatID === message.user.id
 			});
 
 			return (


### PR DESCRIPTION
This is actually what you do in the `step-five` branch. https://github.com/rynclark/flux-getting-started/blob/step-five/public/src/js/partials/userList.jsx#L80

Don't know why it wasn't carried over to the beginner boilerplate.
